### PR TITLE
FIX: Support Discourse's Ember 5 build

### DIFF
--- a/common/header.html
+++ b/common/header.html
@@ -1,4 +1,4 @@
-<script>
+<script type="text/discourse-plugin"  version="0.8">
 // slick.min
 // 10kb gzip
 // author: Ken Wheeler


### PR DESCRIPTION
slick.min expects JQuery to be available as a global. Under Discourse's Ember 5 build this happens a little later than before. Setting type=text/discourse-plugin will make the slick code run after Discourse has booted and set up the JQuery global shim.